### PR TITLE
Validates PR to master

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -10,6 +10,10 @@ CODENARC_REPORT_ARTIFACT = {:message => "Codenarc Report", :path => "codenarc/Co
 
 artifacts = []
 
+pr_to_master = github.branch_for_base == "master"
+valid_title_for_master = github.pr_title.include? "(hotfix)" || github.pr_title.include? "-> master"
+fail "Invalid PR to master! Only integration or hotfix PR are allowed in master branch." if pr_to_master && !valid_title_for_master
+
 if File.file?(TESTING_REPORT)
     junit.parse TESTING_REPORT
     junit.report


### PR DESCRIPTION
# Related tasks
+ [Modificar el script de Danger para que al hacer un PR a master, verifique que sea un PR de integración](http://manoderecha.net/md/index.php/task/135384)

# Problem description
+ PRs are being sent by mistake to the `master` branch instead of the `development` branch.

# Solution description
+ Added validation that checks for incorrect PRs sent to master, and outputs an error message.

# Testing
+ Cannot test changes locally.