### PR TITLE
Closes invalid PR to master

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -12,7 +12,10 @@ artifacts = []
 
 pr_to_master = github.branch_for_base == "master"
 valid_title_for_master = (github.pr_title.include? "(hotfix)") || (github.pr_title.include? "-> master")
-fail "Invalid PR to master! Only integration or hotfix PR are allowed in master branch." if pr_to_master && !valid_title_for_master
+if pr_to_master && !valid_title_for_master
+	github.api.close_pull_request(github.pr_json["base"]["repo"]["full_name"], github.pr_json["number"])
+	fail "Invalid PR to master! Only integration or hotfix PR are allowed in master branch."
+end
 
 if File.file?(TESTING_REPORT)
     junit.parse TESTING_REPORT


### PR DESCRIPTION
# Related task
+ [Modificar el script de Danger para que al hacer un PR a master, verifique que sea un PR de integración](http://manoderecha.net/md/index.php/task/135384)

# Problem description
+ Invalid PRs to master stay open and circleci doesn't trigger a rebuild even after updating the PR in github.

# Solution description
+ Automatically close invalid PR to master.

# Testing
+ Running similar code in Ruby compiler
+ Closing a PR cannot be tested locally