### PR TITLE
Task 138268: Add validation to check commit to update core version

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -17,6 +17,11 @@ if pr_to_master && !valid_title_for_master
 	fail "Invalid PR to master! Only integration or hotfix PR are allowed in master branch."
 end
 
+pr_to_core_repo = github.pr_json["base"]["repo"]["name"].include? "-core"
+if pr_to_core_repo && !(git.commits.any? { |commit| commit.message =~ /\(version\)/ })
+    fail "It is necessary to update core version"
+end
+
 if File.file?(TESTING_REPORT)
     junit.parse TESTING_REPORT
     junit.report


### PR DESCRIPTION
# Related tasks
+ [Añadir validación de commit para actualización de versión](http://manoderecha.net/md/index.php/task/138268)

# Problem description
+ Necessary to set warn message when commit with version is not submitted for core repositories

# Solution description
+ Added logic to check that repository name contains `-core`
+ Added logic to validate a commit that contains message `(version)`

# Testing
+ Running code in ruby console 