### PR TITLE
140604: Update version commit and warn changing circle

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,5 +1,7 @@
 require 'ox'
 
+CIRCLE_FILE_LIST = ["circle.yml", ".circleci/config.yml"]
+
 TESTING_REPORT = "target/test-reports/TESTS-TestSuites.xml"
 COVERAGE_REPORT = "target/test-reports/cobertura/coverage.xml"
 CODENARC_REPORT = "target/CodeNarcReport.xml"
@@ -20,6 +22,10 @@ end
 pr_to_core_repo = github.pr_json["base"]["repo"]["name"].include? "-core"
 if pr_to_core_repo && !(git.commits.any? { |commit| commit.message =~ /\(version\)/ })
     fail "It is necessary to update core version"
+end
+
+if CIRCLE_FILE_LIST.any? { |file| git.modified_files.include?(file) }
+  warn "You are updating circle."
 end
 
 if File.file?(TESTING_REPORT)

--- a/Dangerfile
+++ b/Dangerfile
@@ -20,7 +20,7 @@ if pr_to_master && !valid_title_for_master
 end
 
 pr_to_core_repo = github.pr_json["base"]["repo"]["name"].include? "-core"
-if pr_to_core_repo && !(git.commits.any? { |commit| commit.message =~ /\(version\)/ })
+if pr_to_core_repo && !(git.commits.last =~ /version:/)
     fail "It is necessary to update core version"
 end
 


### PR DESCRIPTION
# Related tasks
+ [Ajustar búsqueda de commit para actualizar versión en core y warning al configurar archivo de circle](http://manoderecha.net/md/index.php/task/140604)

# Problem description
+ Commit to change core version is looked for in all and must be the last one.
+ Nothings is triggered when updating circle files

# Solution description
+ Updated search for core version only in the last commit
+ Added warn when updating circle files

# Testing
+ Running code in ruby console 