### PR TITLE
Task 152441: Add links to report artifacts

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -6,6 +6,12 @@ TESTING_REPORT = "build/reports/test/xml/merge/TESTS-TestSuites.xml"
 COVERAGE_REPORT = "build/reports/clover/clover.xml"
 CODENARC_REPORT = "build/reports/codenarc/codenarc.xml"
 
+TESTING_REPORT_ARTIFACT = {:message => "Test Report", :path => "test/html/index.html"}
+COVERAGE_REPORT_ARTIFACT = {:message => "Coverage Report", :path => "clover/html/index.html"}
+CODENARC_REPORT_ARTIFACT = {:message => "Codenarc Report", :path => "codenarc/codenarc.html"}
+
+artifacts = []
+
 pr_to_master = github.branch_for_base == "master"
 valid_title_for_master = (github.pr_title.include? "hotfix:") || (github.pr_title.include? "-> master")
 if pr_to_master && !valid_title_for_master
@@ -25,6 +31,8 @@ end
 if File.file?(TESTING_REPORT)
     junit.parse TESTING_REPORT
     junit.report
+
+    artifacts << TESTING_REPORT_ARTIFACT
 else
     warn "You are not running tests."
 end
@@ -56,6 +64,8 @@ if File.file?(COVERAGE_REPORT)
     end
     
     markdown cobertura
+
+    artifacts << COVERAGE_REPORT_ARTIFACT
 else
     warn "Coverage report is missing."
 end
@@ -103,8 +113,39 @@ if File.file?(CODENARC_REPORT)
     end
     
     markdown codenarc_md
+
+    artifacts << CODENARC_REPORT_ARTIFACT
 else
     warn "Codenarc report is missing."
+end
+
+# Based on https://github.com/samdmarshall/danger/blob/master/Dangerfile
+if !artifacts.empty?
+    username = ENV['CIRCLE_PROJECT_USERNAME']
+    project_name = ENV['CIRCLE_PROJECT_REPONAME']
+    build_number = ENV['CIRCLE_BUILD_NUM']
+    node_index = ENV['CIRCLE_NODE_INDEX']
+    repo_id = github.pr_json["base"]["repo"]["id"]
+    should_display_message = username && project_name && build_number && node_index
+    
+    if should_display_message
+
+        # build the path to where the circle CI artifacts will be uploaded to
+        circle_ci_artifact_path  = 'https://'
+        circle_ci_artifact_path += build_number
+        circle_ci_artifact_path += '-'
+        circle_ci_artifact_path += repo_id.to_s
+        circle_ci_artifact_path += '-gh.circle-artifacts.com/'
+        circle_ci_artifact_path += node_index
+        circle_ci_artifact_path += '/reports/'
+        
+        artifacts.each do |artifact|
+            # create a markdown link that uses the message text and the artifact path
+            message_string = '[' + artifact[:message] + ']'
+            message_string += '(' + circle_ci_artifact_path + artifact[:path] + ')'
+            message(message_string)
+        end
+    end
 end
 
 # From https://github.com/Moya/Aeryn/blob/master/Dangerfile


### PR DESCRIPTION
# Related tasks
+ [Configurar danger para incluir links a reportes en grails 3](https://manoderecha.net/md/index.php/task/152441)

# Problem description
+ Links to reports are not generated for Grails 3

# Solution description
+ Add links to report artifacts